### PR TITLE
Added description field to Chunks 

### DIFF
--- a/chunks/admin.py
+++ b/chunks/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from models import Chunk
 
 class ChunkAdmin(admin.ModelAdmin):
-  list_display = ('key',)
+  list_display = ('key','description',)
   search_fields = ('key', 'content')
 
 admin.site.register(Chunk, ChunkAdmin)

--- a/chunks/migrations/0001_initial.py
+++ b/chunks/migrations/0001_initial.py
@@ -1,0 +1,35 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'Chunk'
+        db.create_table('chunks_chunk', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+            ('content', self.gf('django.db.models.fields.TextField')(blank=True)),
+        ))
+        db.send_create_signal('chunks', ['Chunk'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'Chunk'
+        db.delete_table('chunks_chunk')
+
+
+    models = {
+        'chunks.chunk': {
+            'Meta': {'object_name': 'Chunk'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['chunks']

--- a/chunks/migrations/0002_auto__add_field_chunk_description.py
+++ b/chunks/migrations/0002_auto__add_field_chunk_description.py
@@ -1,0 +1,31 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'Chunk.description'
+        db.add_column('chunks_chunk', 'description', self.gf('django.db.models.fields.CharField')(default='', max_length=64, blank=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'Chunk.description'
+        db.delete_column('chunks_chunk', 'description')
+
+
+    models = {
+        'chunks.chunk': {
+            'Meta': {'object_name': 'Chunk'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['chunks']

--- a/chunks/models.py
+++ b/chunks/models.py
@@ -9,6 +9,7 @@ class Chunk(models.Model):
     """
     key = models.CharField(help_text="A unique name for this chunk of content", blank=False, max_length=255, unique=True)
     content = models.TextField(blank=True)
+    description = models.CharField(blank=True, max_length=64, help_text="Short Description")
 
     def __unicode__(self):
         return u"%s" % (self.key,)


### PR DESCRIPTION
Hi Clinton,

I like your django chunks project.  Simple, easy to use, and effective.  I thought that I might add an optional description field to the model so users of the django admin can have more to go on than the slug alone for identifying where on the site the chunk belongs.   Thought you might be interested in the changes. 

Cheers, 
Joe
