### PR TITLE
update setup.py for proper `pip freeze` & `pip install -r requirements` behavior

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-setup(name='chunks',
+setup(name='django-chunks',
       version='0.1',
       description='Keyed blocks of content for use in your Django templates',
       author='Clint Ecker',


### PR DESCRIPTION
pip installs the package named 'django-chunks', but freezes it as 'chunks'. So when you try to `pip install -r requirements`, it fails because it can't find a 'chunks' package. updating the name in setup.py should fix this.
