### PR TITLE
Thanks for django-chunks!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='django-chunks',
-      version='0.1',
+      version='0.2',
       description='Keyed blocks of content for use in your Django templates',
       author='Clint Ecker',
       author_email='me@clintecker.com',


### PR DESCRIPTION
django-chunks-0.2.tar.gz on code.google.com still says version='0.1' so pip freeze gives the old version.
